### PR TITLE
Potential fix for code scanning alert no. 2: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
+			 .csrf()
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Potential fix for [https://github.com/feeds-devel/ghas-bootcamp/security/code-scanning/2](https://github.com/feeds-devel/ghas-bootcamp/security/code-scanning/2)

To fix the problem, remove the `.disable()` call on the CSRF configuration so that CSRF protection remains enabled (the default in Spring Security). This change should be made in the `configure(HttpSecurity http)` method, specifically on line 47. The rest of the security configuration can remain unchanged, as enabling CSRF protection does not interfere with JWT authentication or stateless session management. No additional imports or method definitions are required, as CSRF protection is enabled by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
